### PR TITLE
Changed notifications about Neutrals entering the system to generic type

### DIFF
--- a/Rising Stars/locales/english/RS_alerts.txt
+++ b/Rising Stars/locales/english/RS_alerts.txt
@@ -4,3 +4,5 @@ ALERT_ENEMY_HARVESTED: [color=$4]$3[/color] Harvested!
 ALERT_ENEMY_HARVESTED_DESC: An enemy Harvester has prepared the planet [color=$4]$3[/color] for harvesting, and its resources are theirs for the taking!
 ALERT_ENEMY_HARVESTING: [color=$4]$3[/color] Being Harvested
 ALERT_ENEMY_HARVESTING_DESC: An enemy Harvester has begun preparing the planet [color=$4]$3[/color] for harvesting! If they are not stopped, the planet's resources will be theirs!
+ALERT_NEUTRAL_ENTERED_SYSTEM: [color=$4]$3[/color] detected
+ALERT_NEUTRAL_ENTERED_SYSTEM_DESC: An unidentified sensor contact was detected!

--- a/Rising Stars/scripts/server/regions/RegionObjects.as
+++ b/Rising Stars/scripts/server/regions/RegionObjects.as
@@ -1943,11 +1943,13 @@ tidy class RegionObjects : Component_RegionObjects, Savable {
 						int value = round(dsg.size);
 						strengths[obj.owner.index] += value;
 					}
-					if(obj.owner.major) {
-						for(uint i = 0; i < getEmpireCount(); i++) {
-							Empire@ other = getEmpire(i);
-							if(other !is obj.owner && other.major && other.valid && region.getSystemFlag(other, EARLY_WARNING_FLAG) && other.isHostile(obj.owner))
+					for(uint i = 0; i < getEmpireCount(); i++) {
+						Empire@ other = getEmpire(i);
+						if(other !is obj.owner && other.major && other.valid && region.getSystemFlag(other, EARLY_WARNING_FLAG) && other.isHostile(obj.owner)) {
+							if (obj.owner.major)
 								other.notifyWarEvent(region, WET_HostilesInSystem);
+							else
+								other.notifyGeneric(locale::ALERT_NEUTRAL_ENTERED_SYSTEM, locale::ALERT_NEUTRAL_ENTERED_SYSTEM_DESC, "", obj.owner, obj);
 						}
 					}
 				}


### PR DESCRIPTION
Changes the notifications about enemies entering the system to show neutrals, but with a different message than for war events