### PR TITLE
Don't override the modpack's netcode on the server when the shadow netcode still uses the modpack version.

### DIFF
--- a/Rising Stars/scripts/server/planets/SurfaceComponent.as
+++ b/Rising Stars/scripts/server/planets/SurfaceComponent.as
@@ -2604,6 +2604,7 @@ tidy class SurfaceComponent : Component_SurfaceComponent, Savable {
 			msg.write0();
 		}
 		msg.writeBit(needsPopulationForLevel);
+		msg.writeLimited(LevelChainId,getLevelChainCount());
 		msg.writeLimited(ResourceLevel,maxLevel);
 		msg.writeBit(isSendingColonizers);
 	}


### PR DESCRIPTION
Applies the netcode bug fix back to the overridden modpack file.