### PR TITLE
Avoid playing the niling fiber particle effects multiple times while processing the samage damage event

### DIFF
--- a/Rising Stars/scripts/server/heralds_combat.as
+++ b/Rising Stars/scripts/server/heralds_combat.as
@@ -79,8 +79,12 @@ DamageEventStatus NilingAbsorb(DamageEvent& evt, const vec2u& position, double D
 	double value = bp.decimal(sys, 0);
 	value += evt.damage;
 
+	bool playedParticles = false;
 	while(value >= Damage) {
-		playParticleSystem("NilingExplosion", evt.target.position, quaterniond(), Radius / 15.0, evt.target.visibleMask);
+		if (!playedParticles) {
+			playParticleSystem("NilingExplosion", evt.target.position, quaterniond(), Radius / 15.0, evt.target.visibleMask);
+			playedParticles = true;
+		}
 		AoEDamage(evt.target, evt.target, vec3d(), Damage * 0.9, Radius, 10.0);
 
 		value -= Damage;


### PR DESCRIPTION
I was doing some tests with Shield Harmonizers and a flagship with niling fiber, and potentially playing the niling fiber animation multiple times per damage event seemed a little prone to causing graphical lag.